### PR TITLE
Block req over budget

### DIFF
--- a/coordinator/computation.go
+++ b/coordinator/computation.go
@@ -34,7 +34,6 @@ func (c *Coordinator) Compute(ctx context.Context, req *pb.ComputeRequest) (*pb.
 	if err == nil {
 		c.Log.Info("Sufficient budget for compute request.")
 	} else {
-		c.Log.Error(err)
 		return nil, err
 	}
 

--- a/coordinator/computation.go
+++ b/coordinator/computation.go
@@ -29,6 +29,15 @@ func (c *Coordinator) Compute(ctx context.Context, req *pb.ComputeRequest) (*pb.
 	c.ReqCounter++
 	c.ReqCounterMux.Unlock()
 
+	err := c.checkSiteBudget(ctx, req)
+	checkErr(c, err)
+	if err == nil {
+		c.Log.Info("Sufficient budget for compute request.")
+	} else {
+		c.Log.Error(err)
+		return nil, err
+	}
+
 	conn, err := c.Dial(c.Conf.CloudAlgoIpPort, c.Conf.CloudAlgoCN)
 
 	checkErr(c, err)

--- a/coordinator/site-registration.go
+++ b/coordinator/site-registration.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 	pb "leap/proto"
 	"strconv"
+	"leap/sqlite"
 )
 
 // TODO: Do we assume a site cannot register with another site's id?
@@ -34,6 +35,13 @@ func (c *Coordinator) RegisterSite(ctx context.Context, req *pb.SiteRegReq) (*pb
 			ipPort:    ipPort,
 		}
 		c.SiteConnectors.Set(siteId, site)
+
+		// TODO: set budget per site
+		err := c.Database.InsertSite(&sqlite.Site{Id: siteId, EpsilonBudget: 1, DeltaBudget: 1})
+		if err != nil {
+			return &pb.SiteRegRes{Success: false}, err
+		}
+
 		msg := "Site " + strconv.Itoa(int(siteId)) + " registered successfully"
 		response := pb.SiteRegRes{Success: true, Msg: msg}
 		c.Log.WithFields(logrus.Fields{"site-id": req.SiteId}).Info("Site successfully registered.")

--- a/leaptests/db_test.go
+++ b/leaptests/db_test.go
@@ -339,10 +339,43 @@ func TestInsertMultipleSiteAccess(t *testing.T) {
 }
 
 func TestGetSiteBudgetSpentByUser(t *testing.T) {
-	// TODO
 	// insert new site
+	err := db.InsertSite(&sqlite.Site{Id: 11, EpsilonBudget: 0.5, DeltaBudget: 0.1})
+	if err != nil {
+		t.Errorf(err.Error())
+	}
 	// insert new user
+	err = db.InsertUser(&sqlite.User{Id: 22, Name: "Max", SaltedPass: "pw123", BudgetSpent: 0, Role: "admin"})
+	if err != nil {
+		t.Errorf(err.Error())
+	}
 	// insert new siteaccess
+	err = db.InsertSiteAccess(&sqlite.SiteAccess{Id: 5, SiteId: 11, UserId: 22})
+	if err != nil {
+		t.Errorf(err.Error())
+	}
 	// insert some queries
+	err = db.InsertQuery(sqlite.Query{Id: 200, ReqId: 10, UserId: 22, SiteId: 11, Epsilon: 0, Delta: 0})
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	eps, delta := db.GetSiteBudgetSpentByUser(11, 22)
+	if eps != 0 {
+		t.Errorf("Epsilon for site is retrieved incorrectly")
+	}
+	if delta != 0 {
+		t.Errorf("Delta for site is retrieved incorrectly")
+	}
+
+	err = db.InsertQuery(sqlite.Query{Id: 201, ReqId: 11, UserId: 22, SiteId: 11, Epsilon: 1.0, Delta: 0.9})
+	err = db.InsertQuery(sqlite.Query{Id: 202, ReqId: 12, UserId: 22, SiteId: 11, Epsilon: 0.1, Delta: 1.3})
+
 	// sum up epsilon & deltas
+	eps, delta = db.GetSiteBudgetSpentByUser(11, 22)
+	if eps != 1.1 {
+		t.Errorf("Epsilon for site is retrieved incorrectly")
+	}
+	if delta != 2.2 {
+		t.Errorf("Delta for site is retrieved incorrectly")
+	}
 }

--- a/leaptests/db_test.go
+++ b/leaptests/db_test.go
@@ -211,7 +211,7 @@ func TestInsertMultipleUsers(t *testing.T) {
 }
 
 func TestInsertSite(t *testing.T) {
-	err := db.InsertSite(&sqlite.Site{Id: 5, Budget: 2.5})
+	err := db.InsertSite(&sqlite.Site{Id: 5, EpsilonBudget: 2.5, DeltaBudget: 0.5})
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -222,18 +222,22 @@ func TestInsertSite(t *testing.T) {
 		t.Errorf("Site id not inserted correctly")
 	}
 
-	if site.Budget != 2.5 {
-		t.Errorf("Site budget not inserted correctly")
+	if site.EpsilonBudget != 2.5 {
+		t.Errorf("Site epsilon budget not inserted correctly")
+	}
+
+	if site.DeltaBudget != 0.5 {
+		t.Errorf("Site delta budget not inserted correctly")
 	}
 }
 
 func TestInsertMultipleSites(t *testing.T) {
-	err := db.InsertSite(&sqlite.Site{Id: 1, Budget: 0})
+	err := db.InsertSite(&sqlite.Site{Id: 1, EpsilonBudget: 0, DeltaBudget: 0.1})
 	if err != nil {
 		t.Errorf(err.Error())
 	}
 
-	err = db.InsertSite(&sqlite.Site{Id: 4, Budget: 0.5})
+	err = db.InsertSite(&sqlite.Site{Id: 4, EpsilonBudget: 0.5, DeltaBudget: 0.75})
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -244,8 +248,12 @@ func TestInsertMultipleSites(t *testing.T) {
 		t.Errorf("Site id not inserted correctly")
 	}
 
-	if site.Budget != 0 {
-		t.Errorf("Site budget not inserted correctly")
+	if site.EpsilonBudget != 0 {
+		t.Errorf("Site epsilon budget not inserted correctly")
+	}
+
+	if site.DeltaBudget != 0.1 {
+		t.Errorf("Site delta budget not inserted correctly")
 	}
 
 	site = db.GetSiteFromId(4)
@@ -254,8 +262,12 @@ func TestInsertMultipleSites(t *testing.T) {
 		t.Errorf("Site id not inserted correctly")
 	}
 
-	if site.Budget != 0.5 {
-		t.Errorf("Site budget not inserted correctly")
+	if site.EpsilonBudget != 0.5 {
+		t.Errorf("Site epsilon budget not inserted correctly")
+	}
+
+	if site.DeltaBudget != 0.75 {
+		t.Errorf("Site delta budget not inserted correctly")
 	}
 }
 
@@ -324,4 +336,13 @@ func TestInsertMultipleSiteAccess(t *testing.T) {
 	if siteaccesses[1].UserId != 3 {
 		t.Errorf("User id not inserted correctly")
 	}
+}
+
+func TestGetSiteBudgetSpentByUser(t *testing.T) {
+	// TODO
+	// insert new site
+	// insert new user
+	// insert new siteaccess
+	// insert some queries
+	// sum up epsilon & deltas
 }

--- a/leaptests/db_test.go
+++ b/leaptests/db_test.go
@@ -22,6 +22,7 @@ func setup() {
 	db.Database = database
 	db.CreateQueryTable()
 	db.CreateUserTable()
+	db.CreateSiteTable()
 	db.CreateSiteAccessTable()
 }
 
@@ -31,7 +32,7 @@ func teardown() {
 }
 
 func TestInsertQuery(t *testing.T) {
-	err := db.InsertQuery(sqlite.Query{ReqId: 1, UserId: 2, Epsilon: 0.1, Delta: 0})
+	err := db.InsertQuery(sqlite.Query{ReqId: 1, UserId: 2, SiteId: 3, Epsilon: 0.1, Delta: 0})
 
 	if err != nil {
 		t.Errorf(err.Error())
@@ -50,6 +51,10 @@ func TestInsertQuery(t *testing.T) {
 		t.Errorf("User id not inserted correctly")
 	}
 
+	if queries[0].SiteId != 3 {
+		t.Errorf("Site id not inserted correctly")
+	}
+
 	if queries[0].Epsilon != 0.1 {
 		t.Errorf("Epsilon not inserted correctly")
 	}
@@ -61,12 +66,12 @@ func TestInsertQuery(t *testing.T) {
 
 func TestMultipleInserts(t *testing.T) {
 
-	err := db.InsertQuery(sqlite.Query{ReqId: 2, UserId: 4, Epsilon: 0.1, Delta: 0})
+	err := db.InsertQuery(sqlite.Query{ReqId: 2, UserId: 4, SiteId: 5, Epsilon: 0.1, Delta: 0})
 	if err != nil {
 		t.Errorf(err.Error())
 	}
 
-	err = db.InsertQuery(sqlite.Query{ReqId: 3, UserId: 4, Epsilon: 0.2, Delta: 0.3})
+	err = db.InsertQuery(sqlite.Query{ReqId: 3, UserId: 4, SiteId: 6, Epsilon: 0.2, Delta: 0.3})
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -86,6 +91,10 @@ func TestMultipleInserts(t *testing.T) {
 		t.Errorf("User id not inserted correctly")
 	}
 
+	if queries[0].SiteId != 5 {
+		t.Errorf("Site id not inserted correctly")
+	}
+
 	if queries[0].Epsilon != 0.1 {
 		t.Errorf("Epsilon not inserted correctly")
 	}
@@ -101,6 +110,10 @@ func TestMultipleInserts(t *testing.T) {
 
 	if queries[1].UserId != 4 {
 		t.Errorf("User id not inserted correctly")
+	}
+
+	if queries[1].SiteId != 6 {
+		t.Errorf("Site id not inserted correctly")
 	}
 
 	if queries[1].Epsilon != 0.2 {
@@ -194,6 +207,55 @@ func TestInsertMultipleUsers(t *testing.T) {
 
 	if user.BudgetSpent != 2 {
 		t.Errorf("BudgetSpent not inserted correctly")
+	}
+}
+
+func TestInsertSite(t *testing.T) {
+	err := db.InsertSite(&sqlite.Site{Id: 5, Budget: 2.5})
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	site := db.GetSiteFromId(5)
+	// Check site
+	if site.Id != 5 {
+		t.Errorf("Site id not inserted correctly")
+	}
+
+	if site.Budget != 2.5 {
+		t.Errorf("Site budget not inserted correctly")
+	}
+}
+
+func TestInsertMultipleSites(t *testing.T) {
+	err := db.InsertSite(&sqlite.Site{Id: 1, Budget: 0})
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	err = db.InsertSite(&sqlite.Site{Id: 4, Budget: 0.5})
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	site := db.GetSiteFromId(1)
+	// First site
+	if site.Id != 1 {
+		t.Errorf("Site id not inserted correctly")
+	}
+
+	if site.Budget != 0 {
+		t.Errorf("Site budget not inserted correctly")
+	}
+
+	site = db.GetSiteFromId(4)
+	// Second site
+	if site.Id != 4 {
+		t.Errorf("Site id not inserted correctly")
+	}
+
+	if site.Budget != 0.5 {
+		t.Errorf("Site budget not inserted correctly")
 	}
 }
 

--- a/sqlite/db.go
+++ b/sqlite/db.go
@@ -271,7 +271,7 @@ func (db *Database) GetSiteFromId(siteId int) Site {
 //
 // siteId: id of the site that is queried
 // userId: id of the user who has issued queries
-func (db* Database) GetSiteBudgetSpentByUser(siteId int, userId int) (float64, float64) {
+func (db* Database) GetSiteBudgetSpentByUser(siteId int, userId int64) (float64, float64) {
 	rows, err := db.Database.Query("SELECT * FROM query WHERE user_id=? AND site_id=?", userId, siteId)
 	db.checkErr(err)
 

--- a/sqlite/db.go
+++ b/sqlite/db.go
@@ -31,8 +31,9 @@ type User struct {
 }
 
 type Site struct {
-	Id		int64
-	Budget	float64
+	Id				int64
+	EpsilonBudget	float64
+	DeltaBudget		float64
 }
 
 // Roles for users
@@ -228,7 +229,7 @@ func (db *Database) GetSiteAccessFromUser(userId int) ([]SiteAccess, error) {
 //
 // No args.
 func (db *Database) CreateSiteTable() {
-	statement, err := db.Database.Prepare("CREATE TABLE IF NOT EXISTS site (id INTEGER PRIMARY KEY, budget REAL)")
+	statement, err := db.Database.Prepare("CREATE TABLE IF NOT EXISTS site (id INTEGER PRIMARY KEY, epsilon_budget REAL, delta_budget REAL)")
 	db.checkErr(err)
 	_, err = statement.Exec()
 	db.checkErr(err)
@@ -238,13 +239,13 @@ func (db *Database) CreateSiteTable() {
 //
 // site Site struc containing id and budget
 func (db *Database) InsertSite(site *Site) error {
-	statement, err := db.Database.Prepare("INSERT INTO site (id, budget) VALUES (?, ?)")
+	statement, err := db.Database.Prepare("INSERT INTO site (id, epsilon_budget, delta_budget) VALUES (?, ?, ?)")
 	db.checkErr(err)
 	if err != nil {
 		return err
 	}
 
-	_, err = statement.Exec(site.Id, site.Budget)
+	_, err = statement.Exec(site.Id, site.EpsilonBudget, site.DeltaBudget)
 	db.checkErr(err)
 	if err != nil {
 		return err
@@ -258,10 +259,11 @@ func (db *Database) InsertSite(site *Site) error {
 func (db *Database) GetSiteFromId(siteId int) Site {
 	row := db.Database.QueryRow("SELECT * FROM site WHERE id=?", siteId)
 	var id int64
-	var budget float64
-	err := row.Scan(&id, &budget)
+	var epsilonBudget float64
+	var deltaBudget float64
+	err := row.Scan(&id, &epsilonBudget, &deltaBudget)
 	db.checkErr(err)
-	site := Site{id, budget}
+	site := Site{id, epsilonBudget, deltaBudget}
 	return site
 }
 


### PR DESCRIPTION
- Added tests for db insertion of sites & summing up budget spent by user for a specific site
- Manually tested cases with insufficient & sufficient budget when issuing queries with api/example.py

Currently, the code for getting the userId from the jwt claims/token is duplicated in checkSiteBudget, but not entirely sure if there's another cleaner way to get the user id from metadata without re-validating the token.